### PR TITLE
Add boilerplate functions for startPeriodic and stopPeriodic

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,24 @@ class NomadExecutor extends Executor {
     }
 
     /**
+     * Starts a new periodic build in an executor
+     * @method _startPeriodic
+     * @return {Promise}  Resolves to null since it's not supported
+     */
+    _startPeriodic() {
+        return Promise.resolve(null);
+    }
+
+    /**
+     * Stops a new periodic build in an executor
+     * @method _stopPeriodic
+     * @return {Promise}  Resolves to null since it's not supported
+     */
+    _stopPeriodic() {
+        return Promise.resolve(null);
+    }
+
+    /**
     * Retreive stats for the executor
     * @method stats
     * @param  {Response} Object          Object containing stats for the executor

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   ],
   "license": "BSD-3-Clause",
   "author": "Greg Fausak <lgfausak@gmail.com>",
-  "contributors": ["Ethan Haynes <eghaynes17@gmail.com>"],
+  "contributors": [
+    "Ethan Haynes <eghaynes17@gmail.com>"
+  ],
   "release": {
     "debug": false,
     "verifyConditions": {
@@ -46,7 +48,7 @@
     "hoek": "^5.0.2",
     "js-yaml": "^3.6.1",
     "request": "^2.72.0",
-    "screwdriver-executor-base": "^5.2.0",
+    "screwdriver-executor-base": "^6.1.0",
     "tinytim": "^0.1.1"
   },
   "directories": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -336,4 +336,12 @@ describe('index', function () {
             });
         });
     });
+
+    describe('periodic', () => {
+        it('resolves to null when calling periodic start',
+            () => executor.startPeriodic().then(res => assert.isNull(res)));
+
+        it('resolves to null when calling periodic stop',
+            () => executor.stopPeriodic().then(res => assert.isNull(res)));
+    });
 });


### PR DESCRIPTION
Related PR: https://github.com/screwdriver-cd/executor-base/pull/39

We're implementing periodic builds using startPeriodic() and stopPeriodic(), so we're making changes to the executor-base to implement these functions. This PR implements the functions in executor-nomad so things don't break for people using this executor.