### PR TITLE
Add boilerplate functions for startFrozen and stopFrozen

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,24 @@ class NomadExecutor extends Executor {
     }
 
     /**
+     * Starts a new frozen build in an executor
+     * @method _startFrozen
+     * @return {Promise}  Resolves to null since it's not supported
+     */
+    _startFrozen() {
+        return Promise.resolve(null);
+    }
+
+    /**
+     * Stops a new frozen build in an executor
+     * @method _stopFrozen
+     * @return {Promise}  Resolves to null since it's not supported
+     */
+    _stopFrozen() {
+        return Promise.resolve(null);
+    }
+
+    /**
     * Retreive stats for the executor
     * @method stats
     * @param  {Response} Object          Object containing stats for the executor

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "hoek": "^5.0.2",
     "js-yaml": "^3.6.1",
     "request": "^2.87.0",
-    "screwdriver-executor-base": "^6.1.0",
+    "screwdriver-executor-base": "^7.0.0",
     "tinytim": "^0.1.1"
   },
   "directories": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -344,4 +344,12 @@ describe('index', function () {
         it('resolves to null when calling periodic stop',
             () => executor.stopPeriodic().then(res => assert.isNull(res)));
     });
+
+    describe('frozen', () => {
+        it('resolves to null when calling frozen start',
+            () => executor.startFrozen().then(res => assert.isNull(res)));
+
+        it('resolves to null when calling frozen stop',
+            () => executor.stopFrozen().then(res => assert.isNull(res)));
+    });
 });


### PR DESCRIPTION
Related PR: https://github.com/screwdriver-cd/executor-base/pull/52

We're implementing freeze windows for jobs using startFrozen() and stopFrozen(), so we're making changes to the executor-base to implement these functions. This PR implements the functions in executor-nomad so things don't break for people using this executor.